### PR TITLE
Define MAHO_IS_CHILD_PROJECT and remove Varien_Autoload

### DIFF
--- a/phpstan-bootstrap-mage-autoload.php
+++ b/phpstan-bootstrap-mage-autoload.php
@@ -14,28 +14,10 @@ if (empty($magentoRootPath)) {
 if (!defined('BP')) {
     define('BP', $magentoRootPath);
 }
+if (!defined('MAHO_IS_CHILD_PROJECT')) {
+    define('MAHO_IS_CHILD_PROJECT', false);
+}
 
 (new ModuleControllerAutoloader('local'))->register();
 (new ModuleControllerAutoloader('core'))->register();
 (new ModuleControllerAutoloader('community'))->register();
-
-/**
- * We replace the original Varien_Autoload autoloader with a custom one in order to prevent errors with invalid classes
- * that are used throughout the Magento core code.
- * The original autoloader would in this case return false and lead to an error in phpstan because the type alias in extension.neon
- * is evaluated afterwards.
- *
- * @see \Varien_Autoload::autoload()
- */
-spl_autoload_register(static function($className) {
-    spl_autoload_unregister([Varien_Autoload::instance(), 'autoload']);
-
-    $classFile = str_replace(' ', DIRECTORY_SEPARATOR, ucwords(str_replace('_', ' ', $className)));
-    $classFile .= '.php';
-
-    foreach (explode(':', get_include_path()) as $path) {
-        if (\file_exists($path . DIRECTORY_SEPARATOR . $classFile)) {
-            return include $classFile;
-        }
-    }
-}, true, true);

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -14,6 +14,9 @@ if (empty($magentoRootPath)) {
 if (!defined('BP')) {
     define('BP', $magentoRootPath);
 }
+if (!defined('MAHO_IS_CHILD_PROJECT')) {
+    define('MAHO_IS_CHILD_PROJECT', false);
+}
 
 define('staticReflection', true);
 
@@ -40,20 +43,3 @@ include_once "Mage/Core/functions.php";
 (new ModuleControllerAutoloader('local'))->register();
 (new ModuleControllerAutoloader('core'))->register();
 (new ModuleControllerAutoloader('community'))->register();
-
-/**
- * Custom autoloader compatible with Varien_Autoload
- * Autoloading is needed only for the PHPStanMagento1\Config\MagentoCore which inherits from some magento classes.
- * PHPStan uses static analysis, so doesn't require autoloading.
- */
-spl_autoload_register(static function($className) {
-
-    $classFile = str_replace(' ', DIRECTORY_SEPARATOR, ucwords(str_replace('_', ' ', $className)));
-    $classFile .= '.php';
-
-    foreach (explode(':', get_include_path()) as $path) {
-        if (\file_exists($path . DIRECTORY_SEPARATOR . $classFile)) {
-            return include $classFile;
-        }
-    }
-}, true, true);


### PR DESCRIPTION
Ref: https://github.com/MahoCommerce/maho/pull/40

We get rid of Varien_Autoload here too, and there are no errors. So I think it's safe to say removing it doesn't cause problems in the core code.