### PR TITLE
Fix return type for `MageCoreConfig::getClassNameConverterFunction()`

### DIFF
--- a/src/Config/MageCoreConfig.php
+++ b/src/Config/MageCoreConfig.php
@@ -35,35 +35,35 @@ final class MageCoreConfig
             'Mage_Core_Model_Config::getModelInstance',
             'Mage_Core_Model_Factory::getModel',
             'Mage_Core_Model_Factory::getSingleton'
-                => fn (string $alias): string => $this->getConfig()->getModelClassName($alias),
+                => fn (string $alias): string|false => $this->getConfig()->getModelClassName($alias),
 
             'Mage::getResourceModel',
             'Mage::getResourceSingleton',
             'Mage_Core_Model_Config::getResourceModelInstance',
             'Mage_Core_Model_Factory::getResourceModel'
-                => fn (string $alias): string => $this->getConfig()->getResourceModelClassName($alias),
+                => fn (string $alias): string|false => $this->getConfig()->getResourceModelClassName($alias),
 
             'Mage::getResourceHelper',
             'Mage_Core_Model_Config::getResourceHelper',
             'Mage_Core_Model_Config::getResourceHelperInstance'
-                => fn (string $alias): string => $this->getConfig()->getResourceHelperClassName($alias),
+                => fn (string $alias): string|false => $this->getConfig()->getResourceHelperClassName($alias),
 
             'Mage::getBlockSingleton',
             'Mage_Core_Block_Abstract::getHelper',
             'Mage_Core_Model_Layout::addBlock',
             'Mage_Core_Model_Layout::createBlock',
             'Mage_Core_Model_Layout::getBlockSingleton'
-                => fn (string $alias): string => $this->getConfig()->getBlockClassName($alias),
+                => fn (string $alias): string|false => $this->getConfig()->getBlockClassName($alias),
 
             'Mage::helper',
             'Mage_Core_Block_Abstract::helper',
             'Mage_Core_Model_Config::getHelperInstance',
             'Mage_Core_Model_Factory::getHelper',
             'Mage_Core_Model_Layout::helper'
-                => fn (string $alias): string => $this->getConfig()->getHelperClassName($alias),
+                => fn (string $alias): string|false => $this->getConfig()->getHelperClassName($alias),
 
             'Mage_Core_Model_Config::getNodeClassInstance'
-                => fn (string $path): string => $this->getConfig()->getNodeClassName($path),
+                => fn (string $path): string|false => $this->getConfig()->getNodeClassName($path),
 
             default => null,
         };


### PR DESCRIPTION
I didn't notice the added return type, but it actually needs to be `string|false`.

Please tag as `3.0.1`

Edit: here's the fatal crash on current main branch: https://github.com/MahoCommerce/maho/actions/runs/13861148560/job/38789710837?pr=66