### PR TITLE
Added `PublicPropertyReflection::getName()`

### DIFF
--- a/src/PhpDoc/BindThisScopeResolverExtension.php
+++ b/src/PhpDoc/BindThisScopeResolverExtension.php
@@ -81,6 +81,7 @@ final class BindThisScopeResolverExtension extends NodeVisitorAbstract implement
             public function getProperty(string $propertyName, ClassMemberAccessAnswerer $scope): ExtendedPropertyReflection
             {
                 return new WrappedExtendedPropertyReflection(
+                    $propertyName,
                     new PublicPropertyReflection(parent::getProperty($propertyName, $scope))
                 );
             }

--- a/src/Reflection/PublicPropertyReflection.php
+++ b/src/Reflection/PublicPropertyReflection.php
@@ -38,6 +38,11 @@ final class PublicPropertyReflection implements PropertyReflection
         return $this->originalProperty->getDocComment();
     }
 
+    public function getName(): string
+    {
+        return $this->originalProperty->getName();
+    }
+
     public function getReadableType(): Type
     {
         return $this->originalProperty->getReadableType();


### PR DESCRIPTION
Since PHPStan 2.1.13 we have these errors: https://github.com/MahoCommerce/maho/actions/runs/14702379327/job/41254314669 which I hope could be solved by this PR