### PR TITLE
Updated PHPStan to 2.1.29

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.17",
+            "version": "2.1.29",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
+                "url": "https://github.com/phpstan/phpstan-phar-composer-source.git",
+                "reference": "git"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
-                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
+                "reference": "d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
                 "shasum": ""
             },
             "require": {
@@ -63,7 +63,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-21T20:55:28+00:00"
+            "time": "2025-09-25T06:58:18+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -114,21 +114,21 @@
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.4",
+            "version": "2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "3e139cbe67fafa3588e1dbe27ca50f31fdb6236a"
+                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/3e139cbe67fafa3588e1dbe27ca50f31fdb6236a",
-                "reference": "3e139cbe67fafa3588e1dbe27ca50f31fdb6236a",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/d6211c46213d4181054b3d77b10a5c5cb0d59538",
+                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0.4"
+                "phpstan/phpstan": "^2.1.29"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -156,9 +156,9 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.4"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.7"
             },
-            "time": "2025-03-18T11:42:40+00:00"
+            "time": "2025-09-26T11:19:08+00:00"
         }
     ],
     "aliases": [],

--- a/src/Config/MageCoreConfig.php
+++ b/src/Config/MageCoreConfig.php
@@ -35,7 +35,7 @@ final class MageCoreConfig
             'Mage_Core_Model_Config::getModelInstance',
             'Mage_Core_Model_Factory::getModel',
             'Mage_Core_Model_Factory::getSingleton'
-                => fn (string $alias): string|false => $this->getConfig()->getModelClassName($alias),
+                => fn (string $alias): string => $this->getConfig()->getModelClassName($alias),
 
             'Mage::getResourceModel',
             'Mage::getResourceSingleton',
@@ -53,17 +53,17 @@ final class MageCoreConfig
             'Mage_Core_Model_Layout::addBlock',
             'Mage_Core_Model_Layout::createBlock',
             'Mage_Core_Model_Layout::getBlockSingleton'
-                => fn (string $alias): string|false => $this->getConfig()->getBlockClassName($alias),
+                => fn (string $alias): string => $this->getConfig()->getBlockClassName($alias),
 
             'Mage::helper',
             'Mage_Core_Block_Abstract::helper',
             'Mage_Core_Model_Config::getHelperInstance',
             'Mage_Core_Model_Factory::getHelper',
             'Mage_Core_Model_Layout::helper'
-                => fn (string $alias): string|false => $this->getConfig()->getHelperClassName($alias),
+                => fn (string $alias): string => $this->getConfig()->getHelperClassName($alias),
 
             'Mage_Core_Model_Config::getNodeClassInstance'
-                => fn (string $path): string|false => $this->getConfig()->getNodeClassName($path),
+                => fn (string $path): string => $this->getConfig()->getNodeClassName($path),
 
             default => null,
         };

--- a/src/PhpDoc/BindThisScopeResolverExtension.php
+++ b/src/PhpDoc/BindThisScopeResolverExtension.php
@@ -16,8 +16,6 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassMemberAccessAnswerer;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ExtendedPropertyReflection;
-use PHPStan\Reflection\WrappedExtendedMethodReflection;
-use PHPStan\Reflection\WrappedExtendedPropertyReflection;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use function count;
@@ -74,16 +72,11 @@ final class BindThisScopeResolverExtension extends NodeVisitorAbstract implement
         return new class($className) extends ObjectType {
             public function getMethod(string $methodName, ClassMemberAccessAnswerer $scope): ExtendedMethodReflection
             {
-                return new WrappedExtendedMethodReflection(
-                    new PublicMethodReflection(parent::getMethod($methodName, $scope))
-                );
+                return new PublicMethodReflection(parent::getMethod($methodName, $scope));
             }
             public function getProperty(string $propertyName, ClassMemberAccessAnswerer $scope): ExtendedPropertyReflection
             {
-                return new WrappedExtendedPropertyReflection(
-                    $propertyName,
-                    new PublicPropertyReflection(parent::getProperty($propertyName, $scope))
-                );
+                return new PublicPropertyReflection(parent::getProperty($propertyName, $scope));
             }
         };
     }

--- a/src/Reflection/PublicMethodReflection.php
+++ b/src/Reflection/PublicMethodReflection.php
@@ -5,14 +5,23 @@ namespace Maho\PHPStanPlugin\Reflection;
 use PHPStan\Reflection\Assertions;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
 
-final class PublicMethodReflection implements MethodReflection
+/**
+ * Wrapper that exposes protected/private methods as public.
+ *
+ * Note: This class implements PHPStan\Reflection\ExtendedMethodReflection which is not
+ * covered by PHPStan's backward compatibility promise. This is necessary for PHPStan
+ * extension development and is an accepted trade-off for this plugin.
+ *
+ * @phpstan-ignore phpstanApi.interface
+ */
+final class PublicMethodReflection implements ExtendedMethodReflection
 {
-    public function __construct(private MethodReflection $originalMethod)
+    public function __construct(private ExtendedMethodReflection $originalMethod)
     {
     }
 
@@ -52,7 +61,7 @@ final class PublicMethodReflection implements MethodReflection
     }
 
     /**
-     * @return list<ParametersAcceptor>
+     * @return list<\PHPStan\Reflection\ExtendedParametersAcceptor>
      */
     public function getVariants(): array
     {
@@ -87,5 +96,74 @@ final class PublicMethodReflection implements MethodReflection
     public function hasSideEffects(): TrinaryLogic
     {
         return $this->originalMethod->hasSideEffects();
+    }
+
+    public function acceptsNamedArguments(): TrinaryLogic
+    {
+        return $this->originalMethod->acceptsNamedArguments();
+    }
+
+    public function getAsserts(): Assertions
+    {
+        return $this->originalMethod->getAsserts();
+    }
+
+    public function getSelfOutType(): ?Type
+    {
+        return $this->originalMethod->getSelfOutType();
+    }
+
+    public function isAbstract(): TrinaryLogic
+    {
+        $result = $this->originalMethod->isAbstract();
+        return $result instanceof TrinaryLogic ? $result : TrinaryLogic::createFromBoolean($result);
+    }
+
+    public function getNamedArgumentsVariants(): ?array
+    {
+        return $this->originalMethod->getNamedArgumentsVariants();
+    }
+
+    public function getOnlyVariant(): \PHPStan\Reflection\ExtendedParametersAcceptor
+    {
+        $variants = $this->getVariants();
+        if (count($variants) !== 1) {
+            throw new \PHPStan\ShouldNotHappenException('Expected exactly one variant, got ' . count($variants));
+        }
+        return $variants[0];
+    }
+
+    public function isFinalByKeyword(): TrinaryLogic
+    {
+        return $this->originalMethod->isFinalByKeyword();
+    }
+
+    public function returnsByReference(): TrinaryLogic
+    {
+        return $this->originalMethod->returnsByReference();
+    }
+
+    public function isBuiltin(): bool
+    {
+        $result = $this->originalMethod->isBuiltin();
+        return $result instanceof TrinaryLogic ? $result->yes() : $result;
+    }
+
+    public function mustUseReturnValue(): TrinaryLogic
+    {
+        return $this->originalMethod->mustUseReturnValue();
+    }
+
+    public function isPure(): TrinaryLogic
+    {
+        return $this->originalMethod->isPure();
+    }
+
+    /**
+     * @return list<\PHPStan\Reflection\AttributeReflection>
+     */
+    public function getAttributes(): array
+    {
+        return $this->originalMethod->getAttributes();
     }
 }

--- a/src/Reflection/PublicPropertyReflection.php
+++ b/src/Reflection/PublicPropertyReflection.php
@@ -3,13 +3,22 @@
 namespace Maho\PHPStanPlugin\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Reflection\ExtendedPropertyReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
 
-final class PublicPropertyReflection implements PropertyReflection
+/**
+ * Wrapper that exposes protected/private properties as public.
+ *
+ * Note: This class implements PHPStan\Reflection\ExtendedPropertyReflection which is not
+ * covered by PHPStan's backward compatibility promise. This is necessary for PHPStan
+ * extension development and is an accepted trade-off for this plugin.
+ *
+ * @phpstan-ignore phpstanApi.interface
+ */
+final class PublicPropertyReflection implements ExtendedPropertyReflection
 {
-    public function __construct(private PropertyReflection $originalProperty)
+    public function __construct(private ExtendedPropertyReflection $originalProperty)
     {
     }
 
@@ -81,5 +90,78 @@ final class PublicPropertyReflection implements PropertyReflection
     public function isInternal(): TrinaryLogic
     {
         return $this->originalProperty->isInternal();
+    }
+
+    public function getNativeType(): Type
+    {
+        return $this->originalProperty->getNativeType();
+    }
+
+    public function hasNativeType(): bool
+    {
+        return $this->originalProperty->hasNativeType();
+    }
+
+    public function getPhpDocType(): Type
+    {
+        return $this->originalProperty->getPhpDocType();
+    }
+
+    public function hasPhpDocType(): bool
+    {
+        return $this->originalProperty->hasPhpDocType();
+    }
+
+    public function isAbstract(): TrinaryLogic
+    {
+        return $this->originalProperty->isAbstract();
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return $this->originalProperty->isFinal();
+    }
+
+    public function isFinalByKeyword(): TrinaryLogic
+    {
+        return $this->originalProperty->isFinalByKeyword();
+    }
+
+    public function isVirtual(): TrinaryLogic
+    {
+        return $this->originalProperty->isVirtual();
+    }
+
+    public function isDummy(): TrinaryLogic
+    {
+        return $this->originalProperty->isDummy();
+    }
+
+    public function isPrivateSet(): bool
+    {
+        return false;
+    }
+
+    public function isProtectedSet(): bool
+    {
+        return false;
+    }
+
+    public function hasHook(string $hookType): bool
+    {
+        return $this->originalProperty->hasHook($hookType);
+    }
+
+    public function getHook(string $hookType): \PHPStan\Reflection\ExtendedMethodReflection
+    {
+        return $this->originalProperty->getHook($hookType);
+    }
+
+    /**
+     * @return list<\PHPStan\Reflection\AttributeReflection>
+     */
+    public function getAttributes(): array
+    {
+        return $this->originalProperty->getAttributes();
     }
 }

--- a/src/Reflection/VarienObjectReflectionExtension.php
+++ b/src/Reflection/VarienObjectReflectionExtension.php
@@ -5,6 +5,7 @@ namespace Maho\PHPStanPlugin\Reflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use Varien_Object;
 use function in_array;
@@ -12,7 +13,7 @@ use function substr;
 
 final class VarienObjectReflectionExtension implements MethodsClassReflectionExtension
 {
-    public function __construct(private bool $enforceDocBlock)
+    public function __construct(private bool $enforceDocBlock, private ReflectionProvider $reflectionProvider)
     {
     }
 
@@ -29,8 +30,11 @@ final class VarienObjectReflectionExtension implements MethodsClassReflectionExt
             return false;
         }
 
-        if ($classReflection->isSubclassOf(Varien_Object::class) && $this->enforceDocBlock) {
-            return false;
+        if ($this->enforceDocBlock && $this->reflectionProvider->hasClass(Varien_Object::class)) {
+            $varienObjectReflection = $this->reflectionProvider->getClass(Varien_Object::class);
+            if ($classReflection->isSubclassOfClass($varienObjectReflection)) {
+                return false;
+            }
         }
 
         return true;

--- a/src/Rules/MageInvalidTypeRule.php
+++ b/src/Rules/MageInvalidTypeRule.php
@@ -71,9 +71,12 @@ final class MageInvalidTypeRule implements Rule
 
         foreach ($aliases as $alias) {
             $className = $fn($alias->getValue());
+            if (is_string($className) && class_exists($className)) {
+                continue;
+            }
             if ($className === false) {
                 $invalidTypes[] = 'bool(false)';
-            } elseif (class_exists($className) === false) {
+            } else {
                 $invalidTypes[] = $className;
             }
         }

--- a/src/Type/MageTypeExtension.php
+++ b/src/Type/MageTypeExtension.php
@@ -64,10 +64,10 @@ final class MageTypeExtension implements DynamicMethodReturnTypeExtension, Dynam
 
         foreach ($aliases as $alias) {
             $className = $fn($alias->getValue());
-            if ($className === false || class_exists($className) === false) {
-                $returnTypes[] = new ConstantBooleanType(false);
-            } else {
+            if (is_string($className) && class_exists($className)) {
                 $returnTypes[] = new ObjectType($className);
+            } else {
+                $returnTypes[] = new ConstantBooleanType(false);
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes all PHPStan errors that appeared after updating PHPStan dependencies. The plugin now passes PHPStan level 10 with strict rules and bleeding edge config with zero errors.

## Changes Made

### 1. Fixed Return Type Annotations in `Config/MageCoreConfig.php`

**Issue:** PHPStan reported that some anonymous functions declared `string|false` return types, but analysis showed they only returned `string`.

**Fix:** Updated return type annotations based on actual Maho core method signatures:
- Methods that only return `string`: `getModelClassName()`, `getBlockClassName()`, `getHelperClassName()`, `getNodeClassName()`
- Methods that return `string|false`: `getResourceModelClassName()`, `getResourceHelperClassName()`

This matches the actual behavior documented in the mock files.

### 2. Removed Non-BC PHPStan Wrapper Classes in `PhpDoc/BindThisScopeResolverExtension.php`

**Issue:** Using `WrappedExtendedMethodReflection` and `WrappedExtendedPropertyReflection` - these are PHPStan internal classes not covered by backward compatibility promise.

**Fix:** Removed the unnecessary double-wrapping. Our `PublicMethodReflection` and `PublicPropertyReflection` classes already implement the required `ExtendedMethodReflection` and `ExtendedPropertyReflection` interfaces, so the wrapper classes added no value.

**Before:**
```php
return new WrappedExtendedMethodReflection(
    new PublicMethodReflection(parent::getMethod($methodName, $scope))
);
```

**After:**
```php
return new PublicMethodReflection(parent::getMethod($methodName, $scope));
```

### 3. Completed Interface Implementation in `Reflection/PublicMethodReflection.php`

**Issue:** Missing several methods required by `ExtendedMethodReflection` interface.

**Fix:** Implemented all required methods:
- `acceptsNamedArguments()` - returns `TrinaryLogic`
- `getAsserts()` - returns `Assertions`
- `getSelfOutType()` - returns optional `Type`
- `getNamedArgumentsVariants()` - returns optional array
- `getOnlyVariant()` - returns `ExtendedParametersAcceptor` (implemented by getting the single variant from `getVariants()`)
- `returnsByReference()` - returns `TrinaryLogic`
- `isBuiltin()` - returns `bool` with conversion from `TrinaryLogic` if needed
- `mustUseReturnValue()` - returns `TrinaryLogic`
- `isPure()` - returns `TrinaryLogic`
- `getAttributes()` - returns list of `AttributeReflection`

Also fixed return type annotations:
- `getVariants()` now properly returns `list<ExtendedParametersAcceptor>`
- `isAbstract()` returns `TrinaryLogic` with conversion from `bool` if needed

Added `@phpstan-ignore phpstanApi.interface` annotation to suppress unavoidable warnings about implementing PHPStan's internal interfaces (necessary for extension development).

### 4. Completed Interface Implementation in `Reflection/PublicPropertyReflection.php`

**Issue:** Missing several methods required by `ExtendedPropertyReflection` interface.

**Fix:** Implemented all required methods:
- `getName()` - returns property name
- `getNativeType()` - returns `Type` (not nullable)
- `getPhpDocType()` - returns `Type` (not nullable)
- `isAbstract()` - returns `TrinaryLogic`
- `isFinal()` - returns `TrinaryLogic`
- `isFinalByKeyword()` - returns `TrinaryLogic`
- `isVirtual()` - returns `TrinaryLogic`
- `isDummy()` - returns `TrinaryLogic`
- `isPrivateSet()` - returns `false` (we expose as public)
- `isProtectedSet()` - returns `false` (we expose as public)
- `hasHook(string $hookType)` - requires hook type parameter
- `getHook(string $hookType)` - requires hook type parameter, returns `ExtendedMethodReflection`
- `getAttributes()` - returns `list<AttributeReflection>`

Changed from implementing `PropertyReflection` to `ExtendedPropertyReflection` (the correct interface that has all these methods).

Added `@phpstan-ignore phpstanApi.interface` annotation to suppress unavoidable warnings about implementing PHPStan's internal interfaces (necessary for extension development).

### 5. Fixed Deprecated Method Call in `Reflection/VarienObjectReflectionExtension.php`

**Issue:** `isSubclassOf()` method is deprecated in favor of `isSubclassOfClass()`.

**Fix:** The new method requires a `ClassReflection` object instead of a string class name. Added `ReflectionProvider` dependency to get the `ClassReflection` for `Varien_Object`, then call `isSubclassOfClass()` with that object.

**Before:**
```php
if ($classReflection->isSubclassOf(Varien_Object::class) && $this->enforceDocBlock) {
    return false;
}
```

**After:**
```php
if ($this->enforceDocBlock && $this->reflectionProvider->hasClass(Varien_Object::class)) {
    $varienObjectReflection = $this->reflectionProvider->getClass(Varien_Object::class);
    if ($classReflection->isSubclassOfClass($varienObjectReflection)) {
        return false;
    }
}
```

The logic remains identical - subclasses of `Varien_Object` must have `@method` tags when `enforceMagicMethodDocBlock` is enabled.

### 6. Fixed Strict Comparison Issues in `Rules/MageInvalidTypeRule.php` and `Type/MageTypeExtension.php`

**Issue:** PHPStan reported "Strict comparison using === between string and false will always evaluate to false" because after type narrowing, `$className` could only be `string`, not `string|false`.

**Fix:** Reordered the logic to check for valid strings first, then handle all other cases:

**Before:**
```php
if ($className === false) {
    // handle false
} elseif (class_exists($className) === false) {
    // handle invalid class
}
```

**After:**
```php
if (is_string($className) && class_exists($className)) {
    // handle valid class
} else {
    // handle false or invalid class
}
```

This avoids the impossible comparison and makes the logic clearer.

## Testing

All changes have been verified with:
```bash
vendor/bin/phpstan analyse
```

Result: **[OK] No errors** at level 10 with bleeding edge config, strict rules, and deprecation rules enabled.

## Notes

The `@phpstan-ignore phpstanApi.interface` annotations in `PublicMethodReflection` and `PublicPropertyReflection` are necessary and acceptable. These classes must implement PHPStan's `Extended*Reflection` interfaces to function as a PHPStan extension. While PHPStan doesn't guarantee backward compatibility for these interfaces, they are fundamental to extension development and this is a documented trade-off for all PHPStan plugins.