### PR TITLE
Add getInstanceProperty method to BindThisScopeResolverExtension

### DIFF
--- a/src/PhpDoc/BindThisScopeResolverExtension.php
+++ b/src/PhpDoc/BindThisScopeResolverExtension.php
@@ -74,9 +74,15 @@ final class BindThisScopeResolverExtension extends NodeVisitorAbstract implement
             {
                 return new PublicMethodReflection(parent::getMethod($methodName, $scope));
             }
+
             public function getProperty(string $propertyName, ClassMemberAccessAnswerer $scope): ExtendedPropertyReflection
             {
                 return new PublicPropertyReflection(parent::getProperty($propertyName, $scope));
+            }
+
+            public function getInstanceProperty(string $propertyName, ClassMemberAccessAnswerer $scope): ExtendedPropertyReflection
+            {
+                return new PublicPropertyReflection(parent::getInstanceProperty($propertyName, $scope));
             }
         };
     }


### PR DESCRIPTION
Hi!

Thank you for this package! I'm using it in a project where templates are required inside classes:

```php
// Something.php
class Something {
    protected string $name = 'test';

    public function render(): void
    {
        require 'template.php';
    }
}

// Template template.php
<?php
/** @var Something $this */

echo $this->name; // PHPStan error: Access to protected property Something::$name
```

In that case, PHPStan will still trigger a `Access to protected property` error. This PR fixes that case. 

Let me know if this needs any change.