### PR TITLE
Add PHPStan 2.1 compatibility for ExtendedMethodReflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "type": "phpstan-extension",
     "license": "MIT",
     "require": {
-        "php": ">= 8.2"
+        "php": ">= 8.2",
+        "phpstan/phpstan": "^2.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,16 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dea653e9ce7d9c9dcbf168c6db2ebda1",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "caae201ce685c2e457b9c88b00cea80b",
+    "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.31",
+            "version": "2.1.38",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
-                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dfaf1f530e1663aa167bc3e52197adb221582629",
+                "reference": "dfaf1f530e1663aa167bc3e52197adb221582629",
                 "shasum": ""
             },
             "require": {
@@ -58,8 +57,10 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-10T14:14:11+00:00"
-        },
+            "time": "2026-01-30T17:12:46+00:00"
+        }
+    ],
+    "packages-dev": [
         {
             "name": "phpstan/phpstan-deprecation-rules",
             "version": "2.0.3",
@@ -109,16 +110,16 @@
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.7",
+            "version": "2.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538"
+                "reference": "1ed9e626a37f7067b594422411539aa807190573"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/d6211c46213d4181054b3d77b10a5c5cb0d59538",
-                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/1ed9e626a37f7067b594422411539aa807190573",
+                "reference": "1ed9e626a37f7067b594422411539aa807190573",
                 "shasum": ""
             },
             "require": {
@@ -151,9 +152,9 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.7"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.8"
             },
-            "time": "2025-09-26T11:19:08+00:00"
+            "time": "2026-01-27T08:10:25+00:00"
         }
     ],
     "aliases": [],
@@ -165,5 +166,5 @@
         "php": ">= 8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Reflection/PublicMethodReflection.php
+++ b/src/Reflection/PublicMethodReflection.php
@@ -2,6 +2,7 @@
 
 namespace Maho\PHPStanPlugin\Reflection;
 
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\Reflection\Assertions;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
@@ -165,5 +166,10 @@ final class PublicMethodReflection implements ExtendedMethodReflection
     public function getAttributes(): array
     {
         return $this->originalMethod->getAttributes();
+    }
+
+    public function getResolvedPhpDoc(): ?ResolvedPhpDocBlock
+    {
+        return $this->originalMethod->getResolvedPhpDoc();
     }
 }


### PR DESCRIPTION
## Summary
- Implements `getResolvedPhpDoc()` method in `PublicMethodReflection` class
- Moves `phpstan/phpstan` from `require-dev` to `require` with `^2.1` constraint

## Context
PHPStan 2.1 added `getResolvedPhpDoc(): ?ResolvedPhpDocBlock` to the `ExtendedMethodReflection` interface. Since this interface is not covered by PHPStan's backward compatibility promise, implementing classes must add new methods when they're introduced.

This change is **not backward compatible** with PHPStan 2.0.x, hence the version constraint update.

## Test plan
- [ ] Run PHPStan analysis on a Maho project with PHPStan 2.1.x