### PR TITLE
ci: pin shivammathur/setup-php to 2.37.1

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@2.37.1
       with:
         php-version: ${{ matrix.php-version }}
 


### PR DESCRIPTION
Pins `shivammathur/setup-php` to `2.37.1`, resolving **GHSA-5wxr-w449-57cm** as flagged by the [org SBOM scan](https://github.com/MahoCommerce/sboms).

Files changed: 1 workflow file(s).