### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@2.37.2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php-version }}
 


### PR DESCRIPTION
Pin all GitHub Actions to full commit SHAs (with version comments) via [pinact](https://github.com/suzuki-shunsuke/pinact), so a moved tag can't swap the action's code under us. Dependabot keeps the SHA and the comment up to date on future releases.